### PR TITLE
Add GOV.UK PaaS manifest

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,9 @@
+---
+applications:
+ - name: framesplits
+   memory: 64M
+   disk_quota: 100M
+   instances: 2
+   buildpacks: 
+     - staticfile_buildpack
+   stack: cflinuxfs3


### PR DESCRIPTION
This PR enables the framesplits app to be deployed on the PaaS quickly.